### PR TITLE
Rever docker build matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        docker-arch: [ linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +23,9 @@ jobs:
         with:
           images: gerbera/gerbera
           tag-sha: true
+          tag-semver: |
+            {{version}}
+            {{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.docker-arch }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.repository == 'gerbera/gerbera' && ( startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' ) }}"
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
By running all the builds in a single job we dont have to worry about building a manifest list ourselves
