### PR TITLE
fix docker ci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
-cmake-build-debug
+cmake-build-*
 Makefile
 CTestTestfile.cmake
 build.ninja


### PR DESCRIPTION
- fix some new clang-tidy readability warnings
- fix some C casts
- clang-tidy: remove several std::move
- clang-tidy: add missing const
- convert two global variables to string_view
- clang-tidy: add some maybe_unused declarations
- clang-tidy: turn equals functions to bool
- clang-tidy: replace string appends with fmt::format
- remove pointless semicolons
- remove const from const cast
- small optimization
- clang-tidy: initialize int
- Haiku build fixes
- Cleanup
- Actions: Fix docker readme update
